### PR TITLE
Python 3 fix

### DIFF
--- a/people_velocity_tracker/scripts/tracker.py
+++ b/people_velocity_tracker/scripts/tracker.py
@@ -123,7 +123,7 @@ class VelocityTracker(object):
         while not rospy.is_shutdown():
             # Remove People Older Than timeout param
             now = rospy.Time.now()
-            for p in self.people.values():
+            for p in list(self.people.values()):
                 if now - p.age() > self.TIMEOUT:
                     del self.people[p.id()]
             self.publish()


### PR DESCRIPTION
This is just a very small fix for the velocity tracker which fails with `RuntimeError: dictionary changed size during iteration` if run with Python 3.